### PR TITLE
[유재우] 인덱스 생성 작업 및 수정

### DIFF
--- a/유재우/신곡 차트.sql
+++ b/유재우/신곡 차트.sql
@@ -1,4 +1,4 @@
--- FIXME: 설명 바꿔라 chart_id와 song_id들을 이용해서 song_in_chart에 INSERT 
+-- 이번 달에 나온 신곡의 차트를 생성 및 조회
 DELIMITER $$
 
 CREATE OR REPLACE PROCEDURE Insert_release_in_chart()
@@ -28,9 +28,32 @@ BEGIN
               WHERE sic.chart_id = output_chart_id 
                 AND sic.song_id = s.song_id
           ) -- 중복 song_id 방지 조건
-    ORDER BY s.Streaming_cnt DESC										-- 스트리밍 횟수 내림차순 정렬
+    ORDER BY a.rel_date DESC										-- 스트리밍 횟수 내림차순 정렬
 	 LIMIT 100;
 END $$
+
+DELIMITER ;
+
+-- 이번 달에 발매된 신곡을 날짜 기준으로 조회하는 기능
+DELIMITER $$
+
+CREATE OR REPLACE PROCEDURE Get_Release_Song()
+BEGIN
+	SELECT s.`name` AS '곡 제목',
+		m.nickname AS '가수',
+		s.genre AS '장르',
+		s.album_id AS '앨범',
+		s.Streaming_cnt AS '재생 횟수',
+		s.`length` AS '곡 길이',
+		a.rel_date AS '발매일'
+	FROM Song_in_Chart sic
+	RIGHT OUTER JOIN Song s ON sic.song_id = s.song_id
+	LEFT OUTER JOIN Chart c ON sic.chart_id = c.chart_id
+	LEFT OUTER JOIN album a ON a.album_id = s.album_id
+	LEFT OUTER JOIN member m ON m.member_id = a.member_id
+	WHERE c.`name` LIKE '신곡'
+	ORDER BY a.rel_date DESC;
+END$$
 
 DELIMITER ;
 
@@ -38,4 +61,4 @@ DELIMITER ;
 -- CALL Insert_release_in_chart();
 
 -- 신곡 차트 조회
--- CALL Get_Chart('신곡');
+-- CALL Get_Release_Song();

--- a/유재우/인덱스 생성 쿼리(앨범, {차트,노래}).sql
+++ b/유재우/인덱스 생성 쿼리(앨범, {차트,노래}).sql
@@ -1,0 +1,25 @@
+-- Album 테이블
+-- rel_date: 연대별 차트를 삽입하는 프로시저에서 WHERE a.rel_date >= ... 조건으로 연도를 필터링하므로 인덱스를 생성합니다.
+CREATE INDEX idx_album_rel_date ON Album(rel_date);
+
+-- Song_In_Chart 테이블
+-- chart_id, song_id: 이 두 컬럼은 자주 함께 사용되며, 
+-- 특히 삭제(DELETE FROM Song_In_Chart WHERE chart_id = ...) 및 삽입 시 활용되므로 복합(composite) 인덱스를 생성합니다.
+CREATE INDEX idx_song_in_chart ON Song_In_Chart(chart_id, song_id);
+
+
+-- 쿼리 실행 계획을 분석하여 인덱스가 제대로 사용되는지 확인합니다.
+EXPLAIN SELECT chart_id FROM Chart WHERE name = '신곡';
+EXPLAIN SELECT s.song_id FROM Song s WHERE s.genre = 'K-POP' ORDER BY s.Streaming_cnt DESC LIMIT 100;
+
+-- 프로파일 켜기
+SET profiling = 1;
+
+-- 실행할 쿼리
+SELECT s.song_id FROM Song s WHERE s.genre = 'K-POP' ORDER BY s.Streaming_cnt DESC LIMIT 100;
+
+-- 프로파일링 결과 확인
+SHOW PROFILES;
+
+-- 프로파일 끄기
+SET profiling = 0;

--- a/유재우/차트 쿼리.sql
+++ b/유재우/차트 쿼리.sql
@@ -4,10 +4,11 @@ INSERT INTO Chart (`name`) VALUES
 ;
 
 -- 장르별 차트 추가
-INSERT INTO chart (`name`)
-VALUES 
+INSERT INTO chart (`name`) VALUES 
     ('인디'), ('랩'), ('K-POP'), ('발라드'), ('트로트')
 ;
+
+INSERT INTO chart (`name`) VALUES ('신곡');
 
 -- 하루가 지나면 실행되는 테이블 삭제 프로시저
 DELIMITER $$
@@ -52,8 +53,8 @@ BEGIN
 END $$
 
 DELIMITER ;
--- CALL Insert_All_In_Chart(94, 93, 92);
--- CALL Get_Chart('2020`s');
+-- CALL Insert_All_In_Chart(1, 2, 3);
+-- CALL Get_Chart('2000`s');
 
 -- 장르 별 노래를 차트에 삽입
 DELIMITER $$
@@ -103,7 +104,8 @@ BEGIN
 		s.genre AS '장르',
 		s.album_id AS '앨범',
 		s.Streaming_cnt AS '재생 횟수',
-		s.`length` AS '곡 길이'
+		s.`length` AS '곡 길이',
+		a.rel_date AS '발매일'
 	FROM Song_in_Chart sic
 	RIGHT OUTER JOIN Song s ON sic.song_id = s.song_id
 	LEFT OUTER JOIN Chart c ON sic.chart_id = c.chart_id

--- a/유재우/하루단위 스케줄러.sql
+++ b/유재우/하루단위 스케줄러.sql
@@ -11,12 +11,10 @@ ON SCHEDULE EVERY 1 DAY 												-- 이벤트가 매일 반복되도록 설�
 STARTS CURRENT_DATE
 DO
 BEGIN
-    DELETE FROM table_name;
-    -- TRUNCATE FROM streaming_count_by_member;
+    TRUNCATE TABLE streaming_count_by_member;
 END$$
 
 DELIMITER ;
 
 -- 이벤트 확인
 SHOW EVENTS;
-


### PR DESCRIPTION
## 생성
### 인덱스 생성
#### Album 테이블
rel_date: 연대별 차트를 삽입하는 프로시저에서 WHERE a.rel_date >= ... 조건으로 연도를 필터링하므로 인덱스를 생성합니다.

### Song_In_Chart 테이블
#### chart_id, song_id: 이 두 컬럼은 자주 함께 사용되며, 
특히 삭제(DELETE FROM Song_In_Chart WHERE chart_id = ...) 및 삽입 시 활용되므로 복합(composite) 인덱스를 생성합니다.

---
## 신곡 기능
신곡을 날짜 기준으로 내림차순하여 조회
